### PR TITLE
add clang.

### DIFF
--- a/tuffix.yml
+++ b/tuffix.yml
@@ -69,6 +69,7 @@
           - clang-13
           - clang-tidy-13
           - clang-format-13
+          - clang
           - lldb
 
     - name: G++ compiler (default version for target Ubuntu release)


### PR DESCRIPTION
By not adding clang, you lose the ability to use clang++. The alternative is to manually use clang-13